### PR TITLE
fix(`lib/utils`): extend support for `aarch64` to Linux

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -29,12 +29,10 @@ get_platform() {
   echo -n $platform
 }
 
-ARCH_PLATFORM="$(get_arch)-$(get_platform)"
-if [[ "$ARCH_PLATFORM" == "aarch64-apple-darwin" ]]; then
-  GH_REPO="https://github.com/VirtusLab/coursier-m1"
-else
-  GH_REPO="https://github.com/coursier/coursier"
-fi
+case "$(get_arch)-$(get_platform)" in
+aarch64-pc-linux | aarch64-apple-darwin) GH_REPO="https://github.com/VirtusLab/coursier-m1" ;;
+*) GH_REPO="https://github.com/coursier/coursier" ;;
+esac
 
 TOOL_NAME="coursier"
 TOOL_TEST="coursier --help"


### PR DESCRIPTION
In the original change, it was macOS that was covered, but Virtus Lab actually ships aarch64/arm64-ready releases for Linux systems too.  Besides using them natively, extending the support for those could come handy when running Linux containers on macOS.